### PR TITLE
Add custom icons for the map

### DIFF
--- a/app/screens/map/Map.js
+++ b/app/screens/map/Map.js
@@ -161,8 +161,8 @@ export default class MapExample extends Component {
                 title={marker.name}
                 description={marker.description}>
                 {/* https://stackoverflow.com/a/33471432/2603230 */}
-                <View style={[styles.markerBackground, { backgroundColor: 'yellow' }]}>
-                  <MaterialCommunityIcons name="office-building" size={20} color={COLORS.CARDINAL} style={styles.markerInnerIcon} />
+                <View style={[styles.markerBackground, { backgroundColor: 'black' }]}>
+                  <MaterialCommunityIcons name={marker.icon} size={20} color={COLORS.WHITE} style={styles.markerInnerIcon} />
                 </View>
               </MapView.Marker>
             ))}
@@ -289,11 +289,13 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
+    borderWidth: 2,
+    borderColor: 'white',
   },
   markerInnerIcon: {
     width: 20,
     height: 20,
-    left: 10,
-    top: 10,
+    left: 8,
+    top: 8,
   }
 });

--- a/app/screens/map/Map.js
+++ b/app/screens/map/Map.js
@@ -161,8 +161,8 @@ export default class MapExample extends Component {
                 title={marker.name}
                 description={marker.description}>
                 {/* https://stackoverflow.com/a/33471432/2603230 */}
-                <View style={[styles.markerBackground, { backgroundColor: 'black' }]}>
-                  <MaterialCommunityIcons name={marker.icon} size={20} color={COLORS.WHITE} style={styles.markerInnerIcon} />
+                <View style={[styles.markerBackground, { backgroundColor: marker.iconBackgroundColor, borderColor: marker.iconBorderColor }]}>
+                  <MaterialCommunityIcons name={marker.icon} size={20} color={marker.iconColor} style={styles.markerInnerIcon} />
                 </View>
               </MapView.Marker>
             ))}
@@ -290,7 +290,6 @@ const styles = StyleSheet.create({
     height: 40,
     borderRadius: 20,
     borderWidth: 2,
-    borderColor: 'white',
   },
   markerInnerIcon: {
     width: 20,

--- a/app/screens/map/Map.js
+++ b/app/screens/map/Map.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import { Alert, Image, ImageBackground, AppRegistry, TouchableHighlight, TouchableOpacity, ScrollView, StyleSheet, View, Text, Dimensions } from 'react-native';
+import { Alert, Image, AppRegistry, TouchableHighlight, TouchableOpacity, ScrollView, StyleSheet, View, Text, Dimensions } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 import _ from "lodash";
 import HTML from '../../HTML';
 import MapView from 'react-native-maps';
-import { Ionicons } from '@expo/vector-icons';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { ICONS, COLORS, STRINGS, DEFAULT_IMAGE } from "../../assets/constants";
 let { width, height } = Dimensions.get('window');
 const ASPECT_RATIO = width / height;
@@ -160,9 +160,10 @@ export default class MapExample extends Component {
                 }}
                 title={marker.name}
                 description={marker.description}>
-                <ImageBackground source={require("../../media/mail.png")} style={styles.markerBackground}>
-                  <Ionicons name="logo-pinterest" size={20} color={COLORS.WHITE} style={styles.markerInnerIcon} />
-                </ImageBackground>
+                {/* https://stackoverflow.com/a/33471432/2603230 */}
+                <View style={[styles.markerBackground, { backgroundColor: 'yellow' }]}>
+                  <MaterialCommunityIcons name="office-building" size={20} color={COLORS.CARDINAL} style={styles.markerInnerIcon} />
+                </View>
               </MapView.Marker>
             ))}
           </MapView>
@@ -285,13 +286,14 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   markerBackground: {
-    width: 60,
-    height: 60,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
   },
   markerInnerIcon: {
     width: 20,
     height: 20,
-    left: 20,
-    top: 20,
+    left: 10,
+    top: 10,
   }
 });

--- a/app/screens/map/Map.js
+++ b/app/screens/map/Map.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
-import { Alert, Image, AppRegistry, TouchableHighlight, TouchableOpacity, ScrollView, StyleSheet, View, Text, Dimensions } from 'react-native';
+import { Alert, Image, ImageBackground, AppRegistry, TouchableHighlight, TouchableOpacity, ScrollView, StyleSheet, View, Text, Dimensions } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 import _ from "lodash";
 import HTML from '../../HTML';
 import MapView from 'react-native-maps';
-import { FONTS, STRINGS, DEFAULT_IMAGE } from "../../assets/constants";
+import { Ionicons } from '@expo/vector-icons';
+import { ICONS, COLORS, STRINGS, DEFAULT_IMAGE } from "../../assets/constants";
 let { width, height } = Dimensions.get('window');
 const ASPECT_RATIO = width / height;
 const LATITUDE = 37.4275;
@@ -12,9 +13,6 @@ const LONGITUDE = -122.1697;
 const LATITUDE_DELTA = 0.0300;
 const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 
-function randomColor() {
-  return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
-}
 export default class MapExample extends Component {
   constructor() {
     super();
@@ -43,13 +41,13 @@ export default class MapExample extends Component {
     this.fetchAuthor(1001803);
 
     fetch(STRINGS.DAILY_URL + "wp-json/tsd/v1/locations")
-    .then(e => e.json()) //convert to json
-    .then(markers => {
-      // for (let section of markers) {
-      // }
-      this.setState({ markers: markers });
-    })
-    .catch(e => {throw e});
+      .then(e => e.json()) //convert to json
+      .then(markers => {
+        // for (let section of markers) {
+        // }
+        this.setState({ markers: markers });
+      })
+      .catch(e => { throw e });
 
     navigator.geolocation.getCurrentPosition(
       position => {
@@ -153,16 +151,20 @@ export default class MapExample extends Component {
               onPress={() => this.toggleStatus()}
             />
 
-          {this.state.markers && this.state.markers.map(marker => (
+            {this.state.markers && this.state.markers.map(marker => (
               <MapView.Marker
                 key={marker.id}
-                coordinate={{latitude: marker.coordinates[0],
-                  longitude: marker.coordinates[1]}}
+                coordinate={{
+                  latitude: marker.coordinates[0],
+                  longitude: marker.coordinates[1]
+                }}
                 title={marker.name}
-                description={marker.description}
-                pinColor = {randomColor()}
-              />
-          ))}
+                description={marker.description}>
+                <ImageBackground source={require("../../media/mail.png")} style={styles.markerBackground}>
+                  <Ionicons name="logo-pinterest" size={20} color={COLORS.WHITE} style={styles.markerInnerIcon} />
+                </ImageBackground>
+              </MapView.Marker>
+            ))}
           </MapView>
         </View>
 
@@ -175,9 +177,10 @@ export default class MapExample extends Component {
             flex: 1,
             backgroundColor: "white",
             borderTopLeftRadius: 20,
-            borderTopRightRadius: 20}}>
+            borderTopRightRadius: 20
+          }}>
 
-          <View style={{
+            <View style={{
               marginTop: 5,
               flex: 0.2,
               alignContent: "center",
@@ -268,7 +271,7 @@ export default class MapExample extends Component {
 
           : <View></View>}
 
-      </View >
+      </View>
 
 
 
@@ -280,5 +283,15 @@ const styles = StyleSheet.create({
     flex: 1,
     height: '100%',
     width: '100%',
+  },
+  markerBackground: {
+    width: 60,
+    height: 60,
+  },
+  markerInnerIcon: {
+    width: 20,
+    height: 20,
+    left: 20,
+    top: 20,
   }
 });


### PR DESCRIPTION
![img_6631](https://user-images.githubusercontent.com/4939421/52185455-a6699c80-27d4-11e9-9d63-b42871d87cd7.PNG)

Sample website JSON:

	"shopping_center": {
		"name": "Stanford Shopping Center",
		...
		"icon": "shopping",
		"iconColor": "#8c1515",
		"iconBackgroundColor": "#000000",
		"iconBorderColor": "white",
		...
	}

`icon` is using [MaterialCommunityIcons](https://materialdesignicons.com/). Use https://oblador.github.io/react-native-vector-icons/ to find the icons (find icons under `MaterialCommunityIcons`).

`iconColor` (default `white`), `iconBackgroundColor` (default `black`), and `iconBorderColor` (default `white`) are all optional.

Resolves #111.