### PR TITLE
Update react-navigation from 2 to 3

### DIFF
--- a/app/config/router.js
+++ b/app/config/router.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createBottomTabNavigator, createStackNavigator } from 'react-navigation';
+import { createBottomTabNavigator, createStackNavigator, createAppContainer } from 'react-navigation';
 import {Image, View, TouchableOpacity, Dimensions} from 'react-native';
 import {STRINGS, MARGINS, HEIGHTS, KEYS, ICONS, COLORS} from '../assets/constants.js';
 import { Ionicons } from '@expo/vector-icons';
@@ -205,7 +205,7 @@ const SignInStack = createStackNavigator({
   headerMode: 'none',
 });
 
-export const Root = createStackNavigator({
+const Root = createStackNavigator({
   Tabs: {
     screen: Tabs,
   },
@@ -222,3 +222,6 @@ export const Root = createStackNavigator({
   mode: 'modal',
   headerMode: 'none'
 });
+
+// https://reactnavigation.org/docs/en/app-containers.html
+export const RootContainer = createAppContainer(Root);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { KeyboardAvoidingView, View, ActivityIndicator, SafeAreaView } from 'react-native';
-import { Root, Tabs } from './app/config/router';
+import { RootContainer, Tabs } from './app/config/router';
 import {COLORS} from './app/assets/constants';
 import { Font } from 'expo';
 class App extends Component {
@@ -32,7 +32,7 @@ class App extends Component {
           <KeyboardAvoidingView
             style={{ flex: 1 }}
             behavior='padding'>
-            <Root />
+            <RootContainer />
           </KeyboardAvoidingView>
         </SafeAreaView>
       </React.Fragment>

--- a/package-lock.json
+++ b/package-lock.json
@@ -961,6 +961,50 @@
         }
       }
     },
+    "@react-navigation/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-vVPUIpCWO3VKVvE5zYDDR/lOy5hHvRm60rQAHTF19vmt3Jqnbs3qqgYovfUAnTBm0crGLcuIwzOuprRIhC4bfQ==",
+      "requires": {
+        "create-react-context": "0.2.2",
+        "hoist-non-react-statics": "^3.0.1",
+        "path-to-regexp": "^1.7.0",
+        "query-string": "^6.2.0",
+        "react-is": "^16.5.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
+    "@react-navigation/native": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.1.4.tgz",
+      "integrity": "sha512-Py9+FDgwT1AvQE+NzVtvcaGF5IxLtFu7XxEaDvcnI8LFeOt/CVESdJJW8kgxJuYhQQzgLZagQ2hwz5kU2I7tYg==",
+      "requires": {
+        "hoist-non-react-statics": "^3.0.1",
+        "react-native-gesture-handler": "~1.0.14",
+        "react-native-safe-area-view": "^0.12.0",
+        "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
     "@types/fbemitter": {
       "version": "2.0.32",
       "resolved": "https://registry.npmjs.org/@types/fbemitter/-/fbemitter-2.0.32.tgz",
@@ -1057,7 +1101,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -1702,22 +1746,22 @@
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -2442,11 +2486,6 @@
         "lodash.some": "^4.4.0"
       }
     },
-    "clamp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3094,7 +3133,7 @@
       "integrity": "sha512-56uBjw1Tph1BKMqRP0yhI136OiID+WBn9YRLjpJ6GTJ1Qwh9bt82rJBK2GiEVF/bNyWb7QkhcrgujIASStg11Q==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "@expo/vector-icons": "github:expo/vector-icons#d0fb774a001b047d223cfa5e9537220b20591efd",
+        "@expo/vector-icons": "github:expo/vector-icons#expo-font-fix",
         "@expo/websql": "^1.0.1",
         "@types/fbemitter": "^2.0.32",
         "@types/invariant": "^2.2.29",
@@ -3156,7 +3195,7 @@
         "qs": "^6.5.0",
         "react-native-branch": "2.2.5",
         "react-native-gesture-handler": "1.0.14",
-        "react-native-maps": "github:expo/react-native-maps#e6f98ff7272e5d0a7fe974a41f28593af2d77bb2",
+        "react-native-maps": "github:expo/react-native-maps#v0.22.1-exp.0",
         "react-native-reanimated": "1.0.0-alpha.11",
         "react-native-screens": "1.0.0-alpha.22",
         "react-native-svg": "8.0.10",
@@ -3968,7 +4007,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3986,11 +4026,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4003,15 +4045,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4114,7 +4159,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4124,6 +4170,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4136,17 +4183,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4163,6 +4213,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4235,7 +4286,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4245,6 +4297,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4320,7 +4373,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4350,6 +4404,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4367,6 +4422,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4405,11 +4461,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -5098,7 +5156,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -5592,12 +5650,12 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -5610,7 +5668,7 @@
     },
     "kind-of": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
       "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
     },
     "klaw": {
@@ -5814,7 +5872,7 @@
     },
     "lottie-react-native": {
       "version": "2.5.0",
-      "resolved": "http://registry.npmjs.org/lottie-react-native/-/lottie-react-native-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lottie-react-native/-/lottie-react-native-2.5.0.tgz",
       "integrity": "sha1-BxG4s0vsd0FVLCS3Hv09TKs0dXE=",
       "requires": {
         "invariant": "^2.2.2",
@@ -6039,12 +6097,12 @@
         },
         "mime-db": {
           "version": "1.23.0",
-          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
           "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
         },
         "mime-types": {
           "version": "2.1.11",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
           "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
           "requires": {
             "mime-db": "~1.23.0"
@@ -6510,7 +6568,7 @@
     },
     "npmlog": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "requires": {
         "ansi": "~0.3.1",
@@ -6712,7 +6770,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
         "object-assign": "^4.0.1"
@@ -6729,7 +6787,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -6892,7 +6950,7 @@
     },
     "pegjs": {
       "version": "0.10.0",
-      "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
       "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "pify": {
@@ -7185,6 +7243,11 @@
         }
       }
     },
+    "react-is": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
+      "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -7267,7 +7330,7 @@
         },
         "pretty-format": {
           "version": "4.3.1",
-          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
           "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
         },
         "yargs": {
@@ -7310,11 +7373,6 @@
       "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-2.2.5.tgz",
       "integrity": "sha1-QHTdY7SXPmOX2c5Q6XtXx3pRjp0="
     },
-    "react-native-dismiss-keyboard": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz",
-      "integrity": "sha1-MohiQrPyMX4SHzrrmwpYXiuHm0k="
-    },
     "react-native-drawer": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/react-native-drawer/-/react-native-drawer-2.5.1.tgz",
@@ -7322,22 +7380,6 @@
       "requires": {
         "prop-types": "^15.5.8",
         "tween-functions": "^1.0.1"
-      }
-    },
-    "react-native-drawer-layout": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/react-native-drawer-layout/-/react-native-drawer-layout-1.3.2.tgz",
-      "integrity": "sha512-fjO0scqbJUfNu2wuEpvywL7DYLXuCXJ2W/zYhWz986rdLytidbys1QGVvkaszHrb4Y7OqO96mTkgpOcP8KWevw==",
-      "requires": {
-        "react-native-dismiss-keyboard": "1.0.0"
-      }
-    },
-    "react-native-drawer-layout-polyfill": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.2.tgz",
-      "integrity": "sha512-XzPhfLDJrYHru+e8+dFwhf0FtTeAp7JXPpFYezYV6P1nTeA1Tia/kDpFT+O2DWTrBKBEI8FGhZnThrroZmHIxg==",
-      "requires": {
-        "react-native-drawer-layout": "1.3.2"
       }
     },
     "react-native-elements": {
@@ -7437,9 +7479,9 @@
       }
     },
     "react-native-safe-area-view": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.11.0.tgz",
-      "integrity": "sha512-N3nElaahu1Me2ltnfc9acpgt1znm6pi8DSadKy79kvdzKwvVIzw0IXueA/Hjr51eCW1BsfNw7D1SgBT9U6qEkA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.12.0.tgz",
+      "integrity": "sha512-UrAXmBC4KNR5K2eczIDZgqceWyKsgG9gmWFerHCvoyApfei8ceBB9u/c//PWCpS5Gt8MRLTmX5jPtzdXo2yNqg==",
       "requires": {
         "hoist-non-react-statics": "^2.3.1"
       }
@@ -7453,9 +7495,9 @@
       }
     },
     "react-native-screens": {
-      "version": "1.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-1.0.0-alpha.12.tgz",
-      "integrity": "sha512-n/XyqUStDjtCymXUhAxG98asvgI8/OSH+v9AaAzUFEqfBwJLY8/UjY6m8PIJSgqRt4aR/Z9nO+A1mcMXw6dMdA=="
+      "version": "1.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-1.0.0-alpha.22.tgz",
+      "integrity": "sha512-kSyAt0AeVU6N7ZonfV6dP6iZF8B7Bce+tk3eujXhzBGsLg0VSLnU7uE9VqJF0xdQrHR91ZjGgVMieo/8df9KTA=="
     },
     "react-native-styled-text": {
       "version": "0.2.0",
@@ -7494,11 +7536,11 @@
       }
     },
     "react-native-tab-view": {
-      "version": "0.0.77",
-      "resolved": "http://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz",
-      "integrity": "sha512-9vjD4Ly1Zlum1Y4g23ODpi/F3gYIUIsKWrsZO/Oh5cuX1eiB1DRVn11nY1z+j/hsQfhfyW6nDlmySyDvYQvYCA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-1.3.2.tgz",
+      "integrity": "sha512-2U+HxDQdjzExoC6gZ+wUhC8v8JjntppsFVU4v4pRvC/1dkN7DJv1k8UEy9+p7ucEaNrcAzu/j5N09Jf4qG36vw==",
       "requires": {
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.1"
       }
     },
     "react-native-vector-icons": {
@@ -7517,22 +7559,28 @@
       "integrity": "sha512-xFJA+N7wh8Ik/17I4QB24e0a0L3atg1ScVehvtYR5UBTgHdzTFA0ZylvXp9gkZt7V+AT5Pni0H3NQItpqSKFoQ=="
     },
     "react-navigation": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-2.18.2.tgz",
-      "integrity": "sha512-H9hkuC+Fyav/zlss4PU8XRjgBPMKXG9uudT7PSAaRi4kuRkGb77OJDZHBW6Vm9QPF9tAKK95AhaS1mbecLM8Yw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-3.2.3.tgz",
+      "integrity": "sha512-0A+cJF+B2uj3bWB4/UKptl1MjT/OcnwRHea0Sbndl0ueA+yqwzd036s6+tQnEP+OhqfLWnKkvzdb13qP3FeSOg==",
       "requires": {
-        "clamp": "^1.0.1",
-        "create-react-context": "0.2.2",
-        "hoist-non-react-statics": "^2.2.0",
-        "path-to-regexp": "^1.7.0",
-        "query-string": "^6.1.0",
-        "react-lifecycles-compat": "^3",
-        "react-native-safe-area-view": "0.11.0",
-        "react-native-screens": "^1.0.0-alpha.11",
-        "react-navigation-deprecated-tab-navigator": "1.3.0",
-        "react-navigation-drawer": "0.5.0",
-        "react-navigation-stack": "0.7.0",
-        "react-navigation-tabs": "0.8.4"
+        "@react-navigation/core": "3.1.1",
+        "@react-navigation/native": "3.1.4",
+        "react-navigation-drawer": "1.1.0",
+        "react-navigation-stack": "1.0.10",
+        "react-navigation-tabs": "1.0.2"
+      },
+      "dependencies": {
+        "react-navigation-tabs": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/react-navigation-tabs/-/react-navigation-tabs-1.0.2.tgz",
+          "integrity": "sha512-ffWPVdo+L0GLbQlLAzH7ITYqh9V9NdqT/juj8QtESH5/2yUqfvqTxQoSowvFIrtiIHHFH6tLoQy1sZZciTxmeg==",
+          "requires": {
+            "hoist-non-react-statics": "^2.5.0",
+            "prop-types": "^15.6.1",
+            "react-lifecycles-compat": "^3.0.4",
+            "react-native-tab-view": "^1.0.0"
+          }
+        }
       }
     },
     "react-navigation-backhandler": {
@@ -7540,26 +7588,18 @@
       "resolved": "https://registry.npmjs.org/react-navigation-backhandler/-/react-navigation-backhandler-1.2.0.tgz",
       "integrity": "sha512-ykY9rAe0bDB7fV75UcTW0xvKKZj5fr6KSooghAQlAryfY34vWBdxiTNMP3s6LEMUtquFaFeXIpushVwz0xfLmw=="
     },
-    "react-navigation-deprecated-tab-navigator": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-navigation-deprecated-tab-navigator/-/react-navigation-deprecated-tab-navigator-1.3.0.tgz",
-      "integrity": "sha512-Cm+qYOPFWbvvcuv0YYX0ioYwLGgw7XAqdhAfpo3sIr3trxRW8871ePmfFOPezjQtz4v6ItjZt6LPgtBAVZoroQ==",
-      "requires": {
-        "react-native-tab-view": "^0.0.77"
-      }
-    },
     "react-navigation-drawer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/react-navigation-drawer/-/react-navigation-drawer-0.5.0.tgz",
-      "integrity": "sha512-F1y593uC6pqBMGH+Omz75oNODEbxB/s0EGO8QtYwu1NmOOEUuuLA+c14zm+pgMsI4HlDabiHxPkWqsgGz25xVQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-navigation-drawer/-/react-navigation-drawer-1.1.0.tgz",
+      "integrity": "sha512-OtO8g+t0pufbL0aiyZ9y2+j7cWIu9+agiaJfOiE2vPDOqGimpVfEYEuWj0xodKVRrEC4xrb8flqoxMxpE0wjdg==",
       "requires": {
-        "react-native-drawer-layout-polyfill": "^1.3.2"
+        "react-native-tab-view": "^1.2.0"
       }
     },
     "react-navigation-stack": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/react-navigation-stack/-/react-navigation-stack-0.7.0.tgz",
-      "integrity": "sha512-3Tbb/SsustBrM9R/qaI6XuOfyqYMVbwkeHFC8NbU890vB0aKZvjAtioWLZ18e/4LgbiOCmoTdp37z3gkGDyNDQ=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/react-navigation-stack/-/react-navigation-stack-1.0.10.tgz",
+      "integrity": "sha512-p+1oJ6lQYzblidOopIX0Tt+0ZvzaTyoPrBU9erMI04LEoa37BovYpWd1NXBIkV5+wfRt/o5R2x+RZ3LUeWpjeA=="
     },
     "react-navigation-tabs": {
       "version": "0.8.4",
@@ -7859,7 +7899,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -8165,7 +8205,7 @@
     },
     "sax": {
       "version": "1.1.6",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
     },
     "schedule": {
@@ -8233,7 +8273,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serve-static": {
@@ -8352,7 +8392,7 @@
         },
         "xmlbuilder": {
           "version": "8.2.2",
-          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
           "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
         }
       }
@@ -8753,7 +8793,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2920,6 +2920,14 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
@@ -7601,27 +7609,6 @@
       "resolved": "https://registry.npmjs.org/react-navigation-stack/-/react-navigation-stack-1.0.10.tgz",
       "integrity": "sha512-p+1oJ6lQYzblidOopIX0Tt+0ZvzaTyoPrBU9erMI04LEoa37BovYpWd1NXBIkV5+wfRt/o5R2x+RZ3LUeWpjeA=="
     },
-    "react-navigation-tabs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/react-navigation-tabs/-/react-navigation-tabs-0.8.4.tgz",
-      "integrity": "sha512-CbS3xIVJVtpu+AYslv0PMLmjddJFVtU3XAhSJ9XnMrKLUJNmnQdW/L0w/Gp5qcBEF9h6bgsY3CoTtp7I6bqyOQ==",
-      "requires": {
-        "hoist-non-react-statics": "^2.5.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-native-tab-view": "^1.0.0"
-      },
-      "dependencies": {
-        "react-native-tab-view": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-1.2.0.tgz",
-          "integrity": "sha512-lpiWi3dog86Fu/W60DU12RKrFv3XuTv0lHMC56t2jlDqxLfVzG9ufV7li6Afl2S2ZicNU1Bob8WPgxVZc8egAA==",
-          "requires": {
-            "prop-types": "^15.6.1"
-          }
-        }
-      }
-    },
     "react-proxy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
@@ -7643,6 +7630,17 @@
       "requires": {
         "global": "^4.3.0",
         "react-proxy": "^1.1.7"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.3.tgz",
+      "integrity": "sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==",
+      "requires": {
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "read-pkg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7525,16 +7525,6 @@
         "pegjs": "^0.10.0"
       }
     },
-    "react-native-swipe-gestures": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.3.tgz",
-      "integrity": "sha512-KOouRzPB2fHFjVombsSdRfYo8SFeNVa4Ho4B5il87DuuF26sPNOtb3je+qaT/xVptedOsCzRPJGbWFMsaBApgg=="
-    },
-    "react-native-swipe-up-down": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-native-swipe-up-down/-/react-native-swipe-up-down-1.0.7.tgz",
-      "integrity": "sha512-8j3mo+ukZBLRfQNz5N/TXLG7hTKTT8fg/2HkWWJ9umRzPz2kDthxzIkntp9QRPVh7h/sRymkhZdtLY3axdO2Zw=="
-    },
     "react-native-swiper": {
       "version": "1.5.14",
       "resolved": "https://registry.npmjs.org/react-native-swiper/-/react-native-swiper-1.5.14.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-native-swipe-gestures": "^1.0.3",
     "react-native-swipe-up-down": "^1.0.7",
     "react-native-swiper": "^1.5.14",
-    "react-navigation": "^2.18.2",
+    "react-navigation": "^3.2.3",
     "react-navigation-backhandler": "^1.2.0",
     "react-navigation-tabs": "^0.8.4",
     "react-transition-group": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-native-swiper": "^1.5.14",
     "react-navigation": "^3.2.3",
     "react-navigation-backhandler": "^1.2.0",
-    "react-navigation-tabs": "^0.8.4",
     "react-transition-group": "^2.5.3",
     "render-if": "^0.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "react-native-nested-listview": "^0.6.0",
     "react-native-render-html": "^3.10.0",
     "react-native-styled-text": "^0.2.0",
-    "react-native-swipe-gestures": "^1.0.3",
-    "react-native-swipe-up-down": "^1.0.7",
     "react-native-swiper": "^1.5.14",
     "react-navigation": "^3.2.3",
     "react-navigation-backhandler": "^1.2.0",


### PR DESCRIPTION
Removed `react-navigation-tabs` from `package.json` because "With react-navigation@^2.0.0, no installation is required."

Also removed unused package `react-native-swipe-gestures` and `react-native-swipe-up-down`.