### PR TITLE
Add loading indicator for maps

### DIFF
--- a/app/screens/map/Map.js
+++ b/app/screens/map/Map.js
@@ -260,6 +260,7 @@ export default class MapExample extends Component {
             ref={map => this.map = map}
             onMapReady={this.onMapReady}
             initialRegion={initialRegion}
+            loadingEnabled={true}
           >
             {this.state.markers && this.state.markers.length && this.state.markers.map(marker => (
               <MapView.Marker


### PR DESCRIPTION
Show a loading indicator (instead of the grid) when the maps are loading.

Fixes #199